### PR TITLE
feat(cli): add include pattern support for selective scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ Thumbs.db
 *.app
 
 # 生成的报告
-*_report_* 
+*_report_*
 # SpecStory explanation file
 .specstory/.what-is-this.md
 
@@ -55,3 +55,5 @@ dlogcover_*.changes
 dlogcover_*.tar.gz
 dlogcover_*.dsc
 .specstory/history/*2025-07-03_06-15Z*
+
+.cache/

--- a/include/dlogcover/cli/config_constants.h
+++ b/include/dlogcover/cli/config_constants.h
@@ -34,6 +34,8 @@ namespace cli {
     constexpr const char* OPTION_OUTPUT_LONG = "--output";
     constexpr const char* OPTION_CONFIG_SHORT = "-c";
     constexpr const char* OPTION_CONFIG_LONG = "--config";
+    constexpr const char* OPTION_INCLUDE_SHORT = "-i";
+    constexpr const char* OPTION_INCLUDE_LONG = "--include";
     constexpr const char* OPTION_EXCLUDE_SHORT = "-e";
     constexpr const char* OPTION_EXCLUDE_LONG = "--exclude";
     constexpr const char* OPTION_LOG_LEVEL_SHORT = "-l";
@@ -124,4 +126,4 @@ namespace env {
 } // namespace config
 } // namespace dlogcover
 
-#endif // DLOGCOVER_CLI_CONFIG_CONSTANTS_H 
+#endif // DLOGCOVER_CLI_CONFIG_CONSTANTS_H

--- a/include/dlogcover/cli/options.h
+++ b/include/dlogcover/cli/options.h
@@ -32,6 +32,7 @@ struct Options {
     std::string log_file;                       ///< 日志文件路径
     std::vector<std::string> excludePatterns;   ///< 排除模式列表
     std::vector<std::string> includePaths;      ///< 头文件搜索路径列表
+    std::vector<std::string> includePatterns;   ///< 仅扫描模式列表（新增）
     LogLevel logLevel;                          ///< 日志级别
     ReportFormat reportFormat;                  ///< 报告格式
     bool showHelp;                              ///< 是否显示帮助

--- a/include/dlogcover/config/config.h
+++ b/include/dlogcover/config/config.h
@@ -30,6 +30,7 @@ struct ScanConfig {
     std::vector<std::string> directories;    ///< 扫描目录列表（相对于项目根目录）
     std::vector<std::string> file_extensions; ///< 文件扩展名列表
     std::vector<std::string> exclude_patterns; ///< 排除模式列表
+    std::vector<std::string> include_patterns; ///< 仅扫描模式列表（新增）
 };
 
 /**

--- a/include/dlogcover/source_manager/source_manager.h
+++ b/include/dlogcover/source_manager/source_manager.h
@@ -29,7 +29,7 @@ struct SourceFileInfo {
 
 /**
  * @brief 源文件管理器类
- * 
+ *
  * 负责收集、管理和提供源文件信息
  */
 class SourceManager {
@@ -83,6 +83,13 @@ private:
     bool shouldExclude(const std::string& path) const;
 
     /**
+     * @brief 检查文件是否匹配include_patterns
+     * @param path 文件路径
+     * @return 如果应包含返回true，否则返回false
+     */
+    bool shouldInclude(const std::string& path) const;
+
+    /**
      * @brief 检查文件类型是否被支持
      * @param path 文件路径
      * @return 如果支持返回true，否则返回false
@@ -108,4 +115,4 @@ private:
 } // namespace source_manager
 } // namespace dlogcover
 
-#endif // DLOGCOVER_SOURCE_MANAGER_SOURCE_MANAGER_H 
+#endif // DLOGCOVER_SOURCE_MANAGER_SOURCE_MANAGER_H

--- a/src/source_manager/source_manager.cpp
+++ b/src/source_manager/source_manager.cpp
@@ -31,6 +31,47 @@ core::ast_analyzer::Result<bool> SourceManager::collectSourceFiles() {
         sourceFiles_.clear();
         pathToIndex_.clear();
 
+        // 优先处理include_patterns，支持glob匹配
+        if (!config_.scan.include_patterns.empty()) {
+            LOG_INFO_FMT("仅扫描include_patterns指定的文件/目录（支持glob），数量: %zu",
+                         config_.scan.include_patterns.size());
+            size_t includeCount = 0;
+            std::vector<std::string> allFiles;
+            // 遍历所有扫描目录，收集所有支持的文件
+            for (const auto& directory : config_.scan.directories) {
+                if (!utils::FileUtils::directoryExists(directory)) {
+                    LOG_WARNING_FMT("目录不存在，跳过: %s", directory.c_str());
+                    continue;
+                }
+                std::vector<std::string> files = utils::FileUtils::listFiles(
+                    directory, [this](const std::string& path) { return isSupportedFileType(path); }, "", true);
+                allFiles.insert(allFiles.end(), files.begin(), files.end());
+            }
+            // 对所有文件做shouldInclude判断
+            for (const auto& filePath : allFiles) {
+                if (!shouldInclude(filePath))
+                    continue;
+                SourceFileInfo fileInfo;
+                fileInfo.path = filePath;
+                fileInfo.relativePath = filePath;  // 可根据需要调整为相对路径
+                fileInfo.size = utils::FileUtils::getFileSize(filePath);
+                fileInfo.isHeader = utils::FileUtils::hasExtension(filePath, ".h") ||
+                                    utils::FileUtils::hasExtension(filePath, ".hpp") ||
+                                    utils::FileUtils::hasExtension(filePath, ".hxx");
+                if (!readFileContent(filePath, fileInfo.content)) {
+                    LOG_WARNING_FMT("无法读取文件内容: %s", filePath.c_str());
+                    continue;
+                }
+                sourceFiles_.push_back(fileInfo);
+                pathToIndex_[filePath] = sourceFiles_.size() - 1;
+                ++includeCount;
+                LOG_DEBUG_FMT("添加include文件: %s, 大小: %lu bytes", filePath.c_str(), fileInfo.size);
+            }
+            LOG_INFO_FMT("include_patterns count: %d, 扫描所有支持的源文件", config_.scan.include_patterns.size());
+            LOG_INFO_FMT("共收集到 %zu 个include文件", includeCount);
+            return core::ast_analyzer::makeSuccess(!sourceFiles_.empty());
+        }
+
         std::vector<std::string> processedDirectories;
 
         // 遍历所有扫描目录
@@ -93,7 +134,7 @@ core::ast_analyzer::Result<bool> SourceManager::collectSourceFiles() {
                 "所有扫描目录都不存在: " + allDirs);
         }
 
-        LOG_INFO_FMT("成功扫描了 %zu 个目录，共收集到 %lu 个源文件", 
+        LOG_INFO_FMT("成功扫描了 %zu 个目录，共收集到 %lu 个源文件",
                      processedDirectories.size(), sourceFiles_.size());
         return core::ast_analyzer::makeSuccess(!sourceFiles_.empty());
     } catch (const std::exception& e) {
@@ -131,7 +172,7 @@ const SourceFileInfo* SourceManager::getSourceFile(const std::string& path) cons
 std::string SourceManager::globToRegex(const std::string& glob) const {
     std::string regex;
     regex.reserve(glob.size() * 2);
-    
+
     for (size_t i = 0; i < glob.size(); ++i) {
         char c = glob[i];
         switch (c) {
@@ -182,8 +223,29 @@ std::string SourceManager::globToRegex(const std::string& glob) const {
                 break;
         }
     }
-    
+
     return regex;
+}
+
+// 仿照shouldExclude实现shouldInclude，支持glob匹配
+bool SourceManager::shouldInclude(const std::string& path) const {
+    for (const auto& pattern : config_.scan.include_patterns) {
+        std::string regexPattern = globToRegex(pattern);
+        try {
+            std::regex regex(regexPattern, std::regex::extended);
+            if (std::regex_search(path, regex)) {
+                LOG_DEBUG_FMT("包含文件: %s, 匹配模式: %s", path.c_str(), pattern.c_str());
+                return true;
+            }
+        } catch (const std::regex_error& e) {
+            LOG_WARNING_FMT("include正则表达式错误，模式: %s, 错误: %s", pattern.c_str(), e.what());
+            if (path.find(pattern) != std::string::npos) {
+                LOG_DEBUG_FMT("包含文件: %s, 简单匹配模式: %s", path.c_str(), pattern.c_str());
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 bool SourceManager::shouldExclude(const std::string& path) const {
@@ -191,7 +253,7 @@ bool SourceManager::shouldExclude(const std::string& path) const {
     for (const auto& pattern : config_.scan.exclude_patterns) {
         // 将glob模式转换为正则表达式
         std::string regexPattern = globToRegex(pattern);
-        
+
         try {
             std::regex regex(regexPattern, std::regex::extended);
             if (std::regex_search(path, regex)) {


### PR DESCRIPTION
Add -i/--include option to scan only files matching given patterns. When include patterns are specified, exclude patterns are ignored.

新增include模式支持，仅扫描匹配指定模式的文件。
当使用include模式时，自动忽略exclude配置。

Log: 新增include模式，支持仅扫描指定文件